### PR TITLE
Dynamic Port, Volume & Container Name and Copy command button

### DIFF
--- a/views/main.php
+++ b/views/main.php
@@ -28,8 +28,25 @@
     <a class="btn btn-primary" href="https://github.com/louislam/uptime-kuma/wiki">Docs</a>
 </div>
 
+<!-- Dynamic Port and Volume Name -->
+<div class="flex container w-50" id="setting_btns">
+    <div class="input-group mt-3">
+        <label for="inp_port" class="input-group-text">Port</label>
+        <input type="number" min="0" max="65535" class="form-control" value="3001" id="inp_port" placeholder="e.g. 3001" />
+    </div>
+    <div class="input-group mt-3">
+        <label for="inp_volume" class="input-group-text">Volume and Container Name</label>
+        <input type="text" class="form-control" value="uptime-kuma" id="inp_volume" placeholder="e.g. uptime-kuma" />
+    </div>
+</div>
+
 <div class="cmd mt-3">
-    docker run -d --restart=always -p <strong>3001</strong>:3001 -v <strong>uptime-kuma</strong>:/app/data --name <strong>uptime-kuma</strong> louislam/uptime-kuma:1
+    docker run -d --restart=always -p <strong id="port_cmd">3001</strong>:3001 -v <strong id="vol_cmd">uptime-kuma</strong>:/app/data --name <strong id="name_cmd">uptime-kuma</strong> louislam/uptime-kuma:1
+</div>
+
+<!-- copy button -->
+<div class="flex mt-3">
+    <button class="btn btn-primary" onclick="copy()">Copy Command</button>
 </div>
 
 <div class="footer">
@@ -38,6 +55,33 @@
 </div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.0.1/js/bootstrap.bundle.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
+    // Update the command based on the input
+    document.getElementById('inp_port').addEventListener('input', function() {
+        document.getElementById('port_cmd').innerText = this.value;
+    });
+
+    document.getElementById('inp_volume').addEventListener('input', function() {
+        let name = this.value.replace(/[^a-z0-9]/gi, '-').toLowerCase(); // Replace invalid characters (only allow a-z and 0-9)
+        document.getElementById('vol_cmd').innerText = name;
+        document.getElementById('name_cmd').innerText = name;
+    });
+
+    const copy = () => {
+        if (!navigator.clipboard) {
+            alert('Your browser does not support clipboard API');
+            return;
+        }
+
+        if (document.getElementById('inp_port').value === '' || document.getElementById('inp_volume').value === '') {
+            alert('Please fill in the port and volume name');
+            return;
+        }
+
+        navigator.clipboard.writeText(document.querySelector('.cmd').innerText);
+        alert('Docker command copied to clipboard! Simply paste it in your terminal and woa-la!');
+    }
+</script>
 </body>
 
 </html>


### PR DESCRIPTION
Hi There!

Each time to run a new instance, I'd copy the docker command and edit the Port and Names manually. That's why I decided to open this pull request, adding these three features to `uptime.kuma.pet`:

- Ability to dynamically edit the port
- Ability to dynamically edit the Volume & Container name
- A simple button to copy the final command to Clipboard

Fig 01: Inputs screenshot

![Main Screenshot](https://github.com/user-attachments/assets/e90cb292-0d1c-4911-bc41-76c07394e754)

Fig 02: Copy button alert:

![image](https://github.com/user-attachments/assets/40bd41b3-0992-4c87-84ee-b5ead0cbb1ab)